### PR TITLE
README: clarify that KVPair is part of package consulapi

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ client, _ := consulapi.NewClient(consulapi.DefaultConfig())
 kv := client.KV()
 
 // PUT a new KV pair
-p := &KVPair{Key: "foo", Value: []byte("test")}
+p := &consulapi.KVPair{Key: "foo", Value: []byte("test")}
 _, err := kv.Put(p, nil)
 if err != nil {
     panic(err)


### PR DESCRIPTION
Just a quick README fix to clarify that the `KVPair` type exists in the `consulapi` package, and that users don't need to create their own.
