### PR TITLE
Added the TTL and Behavior options to SessionEntry

### DIFF
--- a/session.go
+++ b/session.go
@@ -12,6 +12,8 @@ type SessionEntry struct {
 	Node        string
 	Checks      []string
 	LockDelay   time.Duration
+	Behavior    string
+	TTL         string
 }
 
 // Session can be used to query the Session endpoints
@@ -39,6 +41,12 @@ func (s *Session) CreateNoChecks(se *SessionEntry, q *WriteOptions) (string, *Wr
 		if se.LockDelay != 0 {
 			body["LockDelay"] = durToMsec(se.LockDelay)
 		}
+		if se.Behavior != "" {
+			body["Behavior"] = se.Behavior
+		}
+		if se.TTL != "" {
+			body["TTL"] = se.TTL
+		}
 	}
 	return s.create(body, q)
 
@@ -62,6 +70,12 @@ func (s *Session) Create(se *SessionEntry, q *WriteOptions) (string, *WriteMeta,
 		}
 		if len(se.Checks) > 0 {
 			body["Checks"] = se.Checks
+		}
+		if se.Behavior != "" {
+			body["Behavior"] = se.Behavior
+		}
+		if se.TTL != "" {
+			body["TTL"] = se.TTL
 		}
 	}
 	return s.create(obj, q)

--- a/session_test.go
+++ b/session_test.go
@@ -74,6 +74,12 @@ func TestSession_Info(t *testing.T) {
 	if info.LockDelay == 0 {
 		t.Fatalf("bad: %v", info)
 	}
+	if info.Behavior != "release" {
+		t.Fatalf("bad: %v", info)
+	}
+	if info.TTL != "" {
+		t.Fatalf("bad: %v", info)
+	}
 }
 
 func TestSession_Node(t *testing.T) {


### PR DESCRIPTION
Allow API to create Sessions with TTL and/or Behavior settings
