### PR TITLE
add http basic auth support for http consul rest endpoint

### DIFF
--- a/api.go
+++ b/api.go
@@ -223,14 +223,10 @@ func (r *request) toHTTP() (*http.Request, error) {
 
 	// Setup auth
 	if err == nil && r.config.HttpAuth != nil {
-		r.config.HttpAuth.auth(req)
+		req.SetBasicAuth(r.config.HttpAuth.Username, r.config.HttpAuth.Password)
 	}
 
 	return req, err
-}
-
-func (a *HttpBasicAuth) auth(req *http.Request) {
-	req.SetBasicAuth(a.Username, a.Password)
 }
 
 // newRequest is used to create a new request

--- a/api.go
+++ b/api.go
@@ -73,6 +73,15 @@ type WriteMeta struct {
 	RequestTime time.Duration
 }
 
+// HttpBasicAuth is used to authenticate http client with HTTP Basic Authentication
+type HttpBasicAuth struct {
+	// Username to use for HTTP Basic Authentication
+	Username string
+
+	// Password to use for HTTP Basic Authentication
+	Password string
+}
+
 // Config is used to configure the creation of a client
 type Config struct {
 	// Address is the address of the Consul server
@@ -87,6 +96,9 @@ type Config struct {
 	// HttpClient is the client to use. Default will be
 	// used if not provided.
 	HttpClient *http.Client
+
+	// HttpAuth is the auth info to use for http access.
+	HttpAuth *HttpBasicAuth
 
 	// WaitTime limits how long a Watch will block. If not provided,
 	// the agent default values will be used.
@@ -207,7 +219,18 @@ func (r *request) toHTTP() (*http.Request, error) {
 	}
 
 	// Create the HTTP request
-	return http.NewRequest(r.method, urlRaw, r.body)
+	req, err := http.NewRequest(r.method, urlRaw, r.body)
+
+	// Setup auth
+	if err == nil && r.config.HttpAuth != nil {
+		r.config.HttpAuth.auth(req)
+	}
+
+	return req, err
+}
+
+func (a *HttpBasicAuth) auth(req *http.Request) {
+	req.SetBasicAuth(a.Username, a.Password)
 }
 
 // newRequest is used to create a new request


### PR DESCRIPTION
Make possible to use Consul API / REST over secured http with basic auth. This is a case when access to consul rest endpoint is proxing with help of any reverse proxy server securing chanel with basic auth.

Code sample:

	http := http.Client{Transport: &http.Transport{Dial: func(network, addr string) (net.Conn, error) {
		return net.DialTimeout(network, addr, consulApiTimeout)
	}, TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}}

	auth := consulapi.HttpBasicAuth{Username: "test", Password: "12345"}

	config := consulapi.Config{
		Address:    "127.0.0.1:443",
		Scheme:     "https",
		HttpClient: &http,
		HttpAuth:   &auth,
	}

	client, _ := consulapi.NewClient(&config)
	dcs, err = client.Catalog().Datacenters()