### PR TITLE
fixed: body not closed for non HTTP 200 responses

### DIFF
--- a/acl.go
+++ b/acl.go
@@ -34,10 +34,12 @@ func (a *ACL) Create(acl *ACLEntry, q *WriteOptions) (string, *WriteMeta, error)
 	r.setWriteOptions(q)
 	r.obj = acl
 	rtt, resp, err := requireOK(a.c.doRequest(r))
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return "", nil, err
 	}
-	defer resp.Body.Close()
 
 	wm := &WriteMeta{RequestTime: rtt}
 	var out struct{ ID string }
@@ -52,11 +54,13 @@ func (a *ACL) Update(acl *ACLEntry, q *WriteOptions) (*WriteMeta, error) {
 	r := a.c.newRequest("PUT", "/v1/acl/update")
 	r.setWriteOptions(q)
 	r.obj = acl
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	rtt, resp, err := requireOK(a.c.doRequest(r))
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	wm := &WriteMeta{RequestTime: rtt}
 	return wm, nil
@@ -67,10 +71,12 @@ func (a *ACL) Destroy(id string, q *WriteOptions) (*WriteMeta, error) {
 	r := a.c.newRequest("PUT", "/v1/acl/destroy/"+id)
 	r.setWriteOptions(q)
 	rtt, resp, err := requireOK(a.c.doRequest(r))
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	resp.Body.Close()
 
 	wm := &WriteMeta{RequestTime: rtt}
 	return wm, nil
@@ -81,10 +87,12 @@ func (a *ACL) Clone(id string, q *WriteOptions) (string, *WriteMeta, error) {
 	r := a.c.newRequest("PUT", "/v1/acl/clone/"+id)
 	r.setWriteOptions(q)
 	rtt, resp, err := requireOK(a.c.doRequest(r))
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return "", nil, err
 	}
-	defer resp.Body.Close()
 
 	wm := &WriteMeta{RequestTime: rtt}
 	var out struct{ ID string }
@@ -99,10 +107,12 @@ func (a *ACL) Info(id string, q *QueryOptions) (*ACLEntry, *QueryMeta, error) {
 	r := a.c.newRequest("GET", "/v1/acl/info/"+id)
 	r.setQueryOptions(q)
 	rtt, resp, err := requireOK(a.c.doRequest(r))
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, nil, err
 	}
-	defer resp.Body.Close()
 
 	qm := &QueryMeta{}
 	parseQueryMeta(resp, qm)
@@ -123,10 +133,12 @@ func (a *ACL) List(q *QueryOptions) ([]*ACLEntry, *QueryMeta, error) {
 	r := a.c.newRequest("GET", "/v1/acl/list")
 	r.setQueryOptions(q)
 	rtt, resp, err := requireOK(a.c.doRequest(r))
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, nil, err
 	}
-	defer resp.Body.Close()
 
 	qm := &QueryMeta{}
 	parseQueryMeta(resp, qm)

--- a/acl.go
+++ b/acl.go
@@ -54,10 +54,10 @@ func (a *ACL) Update(acl *ACLEntry, q *WriteOptions) (*WriteMeta, error) {
 	r := a.c.newRequest("PUT", "/v1/acl/update")
 	r.setWriteOptions(q)
 	r.obj = acl
+	rtt, resp, err := requireOK(a.c.doRequest(r))
 	if resp != nil {
 		defer resp.Body.Close()
 	}
-	rtt, resp, err := requireOK(a.c.doRequest(r))
 	if err != nil {
 		return nil, err
 	}

--- a/agent.go
+++ b/agent.go
@@ -82,10 +82,12 @@ func (c *Client) Agent() *Agent {
 func (a *Agent) Self() (map[string]map[string]interface{}, error) {
 	r := a.c.newRequest("GET", "/v1/agent/self")
 	_, resp, err := requireOK(a.c.doRequest(r))
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	var out map[string]map[string]interface{}
 	if err := decodeBody(resp, &out); err != nil {
@@ -112,10 +114,12 @@ func (a *Agent) NodeName() (string, error) {
 func (a *Agent) Checks() (map[string]*AgentCheck, error) {
 	r := a.c.newRequest("GET", "/v1/agent/checks")
 	_, resp, err := requireOK(a.c.doRequest(r))
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	var out map[string]*AgentCheck
 	if err := decodeBody(resp, &out); err != nil {
@@ -128,10 +132,12 @@ func (a *Agent) Checks() (map[string]*AgentCheck, error) {
 func (a *Agent) Services() (map[string]*AgentService, error) {
 	r := a.c.newRequest("GET", "/v1/agent/services")
 	_, resp, err := requireOK(a.c.doRequest(r))
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	var out map[string]*AgentService
 	if err := decodeBody(resp, &out); err != nil {
@@ -148,10 +154,12 @@ func (a *Agent) Members(wan bool) ([]*AgentMember, error) {
 		r.params.Set("wan", "1")
 	}
 	_, resp, err := requireOK(a.c.doRequest(r))
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	var out []*AgentMember
 	if err := decodeBody(resp, &out); err != nil {
@@ -166,10 +174,12 @@ func (a *Agent) ServiceRegister(service *AgentServiceRegistration) error {
 	r := a.c.newRequest("PUT", "/v1/agent/service/register")
 	r.obj = service
 	_, resp, err := requireOK(a.c.doRequest(r))
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return err
 	}
-	resp.Body.Close()
 	return nil
 }
 
@@ -178,10 +188,12 @@ func (a *Agent) ServiceRegister(service *AgentServiceRegistration) error {
 func (a *Agent) ServiceDeregister(serviceID string) error {
 	r := a.c.newRequest("PUT", "/v1/agent/service/deregister/"+serviceID)
 	_, resp, err := requireOK(a.c.doRequest(r))
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return err
 	}
-	resp.Body.Close()
 	return nil
 }
 
@@ -213,10 +225,12 @@ func (a *Agent) UpdateTTL(checkID, note, status string) error {
 	r := a.c.newRequest("PUT", endpoint)
 	r.params.Set("note", note)
 	_, resp, err := requireOK(a.c.doRequest(r))
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return err
 	}
-	resp.Body.Close()
 	return nil
 }
 
@@ -226,10 +240,12 @@ func (a *Agent) CheckRegister(check *AgentCheckRegistration) error {
 	r := a.c.newRequest("PUT", "/v1/agent/check/register")
 	r.obj = check
 	_, resp, err := requireOK(a.c.doRequest(r))
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return err
 	}
-	resp.Body.Close()
 	return nil
 }
 
@@ -238,10 +254,12 @@ func (a *Agent) CheckRegister(check *AgentCheckRegistration) error {
 func (a *Agent) CheckDeregister(checkID string) error {
 	r := a.c.newRequest("PUT", "/v1/agent/check/deregister/"+checkID)
 	_, resp, err := requireOK(a.c.doRequest(r))
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return err
 	}
-	resp.Body.Close()
 	return nil
 }
 
@@ -253,10 +271,12 @@ func (a *Agent) Join(addr string, wan bool) error {
 		r.params.Set("wan", "1")
 	}
 	_, resp, err := requireOK(a.c.doRequest(r))
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return err
 	}
-	resp.Body.Close()
 	return nil
 }
 
@@ -264,9 +284,11 @@ func (a *Agent) Join(addr string, wan bool) error {
 func (a *Agent) ForceLeave(node string) error {
 	r := a.c.newRequest("PUT", "/v1/agent/force-leave/"+node)
 	_, resp, err := requireOK(a.c.doRequest(r))
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return err
 	}
-	resp.Body.Close()
 	return nil
 }

--- a/catalog.go
+++ b/catalog.go
@@ -50,10 +50,12 @@ func (c *Catalog) Register(reg *CatalogRegistration, q *WriteOptions) (*WriteMet
 	r.setWriteOptions(q)
 	r.obj = reg
 	rtt, resp, err := requireOK(c.c.doRequest(r))
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	resp.Body.Close()
 
 	wm := &WriteMeta{}
 	wm.RequestTime = rtt
@@ -66,10 +68,12 @@ func (c *Catalog) Deregister(dereg *CatalogDeregistration, q *WriteOptions) (*Wr
 	r.setWriteOptions(q)
 	r.obj = dereg
 	rtt, resp, err := requireOK(c.c.doRequest(r))
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	resp.Body.Close()
 
 	wm := &WriteMeta{}
 	wm.RequestTime = rtt
@@ -81,10 +85,12 @@ func (c *Catalog) Deregister(dereg *CatalogDeregistration, q *WriteOptions) (*Wr
 func (c *Catalog) Datacenters() ([]string, error) {
 	r := c.c.newRequest("GET", "/v1/catalog/datacenters")
 	_, resp, err := requireOK(c.c.doRequest(r))
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	var out []string
 	if err := decodeBody(resp, &out); err != nil {
@@ -98,10 +104,12 @@ func (c *Catalog) Nodes(q *QueryOptions) ([]*Node, *QueryMeta, error) {
 	r := c.c.newRequest("GET", "/v1/catalog/nodes")
 	r.setQueryOptions(q)
 	rtt, resp, err := requireOK(c.c.doRequest(r))
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, nil, err
 	}
-	defer resp.Body.Close()
 
 	qm := &QueryMeta{}
 	parseQueryMeta(resp, qm)
@@ -119,10 +127,12 @@ func (c *Catalog) Services(q *QueryOptions) (map[string][]string, *QueryMeta, er
 	r := c.c.newRequest("GET", "/v1/catalog/services")
 	r.setQueryOptions(q)
 	rtt, resp, err := requireOK(c.c.doRequest(r))
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, nil, err
 	}
-	defer resp.Body.Close()
 
 	qm := &QueryMeta{}
 	parseQueryMeta(resp, qm)
@@ -143,10 +153,12 @@ func (c *Catalog) Service(service, tag string, q *QueryOptions) ([]*CatalogServi
 		r.params.Set("tag", tag)
 	}
 	rtt, resp, err := requireOK(c.c.doRequest(r))
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, nil, err
 	}
-	defer resp.Body.Close()
 
 	qm := &QueryMeta{}
 	parseQueryMeta(resp, qm)
@@ -164,10 +176,12 @@ func (c *Catalog) Node(node string, q *QueryOptions) (*CatalogNode, *QueryMeta, 
 	r := c.c.newRequest("GET", "/v1/catalog/node/"+node)
 	r.setQueryOptions(q)
 	rtt, resp, err := requireOK(c.c.doRequest(r))
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, nil, err
 	}
-	defer resp.Body.Close()
 
 	qm := &QueryMeta{}
 	parseQueryMeta(resp, qm)

--- a/event.go
+++ b/event.go
@@ -47,10 +47,12 @@ func (e *Event) Fire(params *UserEvent, q *WriteOptions) (string, *WriteMeta, er
 	}
 
 	rtt, resp, err := requireOK(e.c.doRequest(r))
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return "", nil, err
 	}
-	defer resp.Body.Close()
 
 	wm := &WriteMeta{RequestTime: rtt}
 	var out UserEvent
@@ -71,10 +73,12 @@ func (e *Event) List(name string, q *QueryOptions) ([]*UserEvent, *QueryMeta, er
 		r.params.Set("name", name)
 	}
 	rtt, resp, err := requireOK(e.c.doRequest(r))
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, nil, err
 	}
-	defer resp.Body.Close()
 
 	qm := &QueryMeta{}
 	parseQueryMeta(resp, qm)

--- a/kv.go
+++ b/kv.go
@@ -175,10 +175,12 @@ func (k *KV) put(key string, params map[string]string, body []byte, q *WriteOpti
 	}
 	r.body = bytes.NewReader(body)
 	rtt, resp, err := requireOK(k.c.doRequest(r))
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return false, nil, err
 	}
-	defer resp.Body.Close()
 
 	qm := &WriteMeta{}
 	qm.RequestTime = rtt
@@ -208,10 +210,12 @@ func (k *KV) deleteInternal(key string, params []string, q *WriteOptions) (*Writ
 		r.params.Set(param, "")
 	}
 	rtt, resp, err := requireOK(k.c.doRequest(r))
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	resp.Body.Close()
 
 	qm := &WriteMeta{}
 	qm.RequestTime = rtt

--- a/session.go
+++ b/session.go
@@ -86,10 +86,12 @@ func (s *Session) create(obj interface{}, q *WriteOptions) (string, *WriteMeta, 
 	r.setWriteOptions(q)
 	r.obj = obj
 	rtt, resp, err := requireOK(s.c.doRequest(r))
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return "", nil, err
 	}
-	defer resp.Body.Close()
 
 	wm := &WriteMeta{RequestTime: rtt}
 	var out struct{ ID string }
@@ -104,10 +106,12 @@ func (s *Session) Destroy(id string, q *WriteOptions) (*WriteMeta, error) {
 	r := s.c.newRequest("PUT", "/v1/session/destroy/"+id)
 	r.setWriteOptions(q)
 	rtt, resp, err := requireOK(s.c.doRequest(r))
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	resp.Body.Close()
 
 	wm := &WriteMeta{RequestTime: rtt}
 	return wm, nil
@@ -118,10 +122,12 @@ func (s *Session) Renew(id string, q *WriteOptions) (*SessionEntry, *WriteMeta, 
 	r := s.c.newRequest("PUT", "/v1/session/renew/"+id)
 	r.setWriteOptions(q)
 	rtt, resp, err := requireOK(s.c.doRequest(r))
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, nil, err
 	}
-	defer resp.Body.Close()
 
 	wm := &WriteMeta{RequestTime: rtt}
 
@@ -141,10 +147,12 @@ func (s *Session) Info(id string, q *QueryOptions) (*SessionEntry, *QueryMeta, e
 	r := s.c.newRequest("GET", "/v1/session/info/"+id)
 	r.setQueryOptions(q)
 	rtt, resp, err := requireOK(s.c.doRequest(r))
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, nil, err
 	}
-	defer resp.Body.Close()
 
 	qm := &QueryMeta{}
 	parseQueryMeta(resp, qm)
@@ -166,10 +174,12 @@ func (s *Session) Node(node string, q *QueryOptions) ([]*SessionEntry, *QueryMet
 	r := s.c.newRequest("GET", "/v1/session/node/"+node)
 	r.setQueryOptions(q)
 	rtt, resp, err := requireOK(s.c.doRequest(r))
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, nil, err
 	}
-	defer resp.Body.Close()
 
 	qm := &QueryMeta{}
 	parseQueryMeta(resp, qm)
@@ -187,10 +197,12 @@ func (s *Session) List(q *QueryOptions) ([]*SessionEntry, *QueryMeta, error) {
 	r := s.c.newRequest("GET", "/v1/session/list")
 	r.setQueryOptions(q)
 	rtt, resp, err := requireOK(s.c.doRequest(r))
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, nil, err
 	}
-	defer resp.Body.Close()
 
 	qm := &QueryMeta{}
 	parseQueryMeta(resp, qm)

--- a/status.go
+++ b/status.go
@@ -14,10 +14,12 @@ func (c *Client) Status() *Status {
 func (s *Status) Leader() (string, error) {
 	r := s.c.newRequest("GET", "/v1/status/leader")
 	_, resp, err := requireOK(s.c.doRequest(r))
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return "", err
 	}
-	defer resp.Body.Close()
 
 	var leader string
 	if err := decodeBody(resp, &leader); err != nil {
@@ -30,10 +32,12 @@ func (s *Status) Leader() (string, error) {
 func (s *Status) Peers() ([]string, error) {
 	r := s.c.newRequest("GET", "/v1/status/peers")
 	_, resp, err := requireOK(s.c.doRequest(r))
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 	if err != nil {
 		return nil, err
 	}
-	defer resp.Body.Close()
 
 	var peers []string
 	if err := decodeBody(resp, &peers); err != nil {


### PR DESCRIPTION
requireOK function does not close the body for HTTP codes != 200.
Also, currently all calls to requireOK return immediately if there is an error and don't even look at the response.
In the end, no one closes the body so it is leaking.

I don't know if requestOK should be fixed, or if the caller should be fixed.
It seems to me that requireOK should be fixed but I was wondering if the current requireOK implementation is returning the response so that the caller may, say, look at the status code and do something rather than simply returning.
Rather than fixing it I assumed handling on the caller side would be acceptable since we still have to close the body for successful responses and that it just introduces an ```if resp != nil {}```` block.

Let me know if this looks good.